### PR TITLE
[#77] Add image thumb format to image caption transformer

### DIFF
--- a/.changeset/large-brooms-visit.md
+++ b/.changeset/large-brooms-visit.md
@@ -1,0 +1,5 @@
+---
+"osrs-web-scraper": patch
+---
+
+Add thumb format to images in image caption transformer

--- a/src/scrapers/news/transformers/__tests__/__snapshots__/imageCaptionTransformer.test.ts.snap
+++ b/src/scrapers/news/transformers/__tests__/__snapshots__/imageCaptionTransformer.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`NewsImageCaptionTransformer should combine the adjacent MediaWikiFile, MediaWikiBreak and MediaWikiImage 1`] = `
-"[[File:image|''caption'']]
+"[[File:image|thumb|''caption'']]
 "
 `;
 
@@ -9,7 +9,7 @@ exports[`NewsImageCaptionTransformer should combine the adjacent MediaWikiFile, 
 "__TOC__
 
 [[test|test]]
-[[File:image|''caption'']]
+[[File:image|thumb|''caption'']]
 
 You can also discuss this update on our
 "

--- a/src/scrapers/news/transformers/imageCaptionTransformer.ts
+++ b/src/scrapers/news/transformers/imageCaptionTransformer.ts
@@ -25,6 +25,7 @@ class NewsImageCaptionTransformer extends MediaWikiTransformer {
           transformedContent.push(
             new MediaWikiFile(current.fileName, {
               ...current.options,
+              format: "thumb",
               caption: second,
             })
           );


### PR DESCRIPTION
**Description**
Add `thumb` to images that are given a caption by `imageCaptionTransformer`.