### PR TITLE
[#67] Set the total votes for a poll if the runtime date is the on or after the poll end date

### DIFF
--- a/.changeset/light-trees-wave.md
+++ b/.changeset/light-trees-wave.md
@@ -1,0 +1,5 @@
+---
+"osrs-web-scraper": patch
+---
+
+Fix poll total parsing

--- a/.changeset/mighty-pens-exercise.md
+++ b/.changeset/mighty-pens-exercise.md
@@ -1,0 +1,5 @@
+---
+"osrs-web-scraper": patch
+---
+
+Include poll total if current date is after or equal to poll end date

--- a/src/scrapers/polls/sections/pollHeader.ts
+++ b/src/scrapers/polls/sections/pollHeader.ts
@@ -5,7 +5,7 @@ import {
   PollNoticeTemplate,
   PollWrapperTemplate,
 } from "@osrs-wiki/mediawiki-builder";
-import { format, parse } from "date-fns";
+import { format, isBefore, parse } from "date-fns";
 import { HTMLElement } from "node-html-parser";
 
 import { PollSection } from "./types";
@@ -24,7 +24,7 @@ const pollHeader: PollSection = {
     );
     const total = htmlElement
       .querySelector("div")
-      .textContent.match(/(\d)*/g)?.[0];
+      .textContent.match(/(\d)+/g)?.[0];
 
     const content: MediaWikiContent[] = [];
 
@@ -54,10 +54,9 @@ const pollHeader: PollSection = {
     content.push(descriptionTemplate);
 
     content.push(new MediaWikiBreak());
-    content.push(new MediaWikiBreak());
 
     const totalTemplate = new MediaWikiTemplate("PollTotal");
-    totalTemplate.add("", total);
+    totalTemplate.add("", isBefore(new Date(), endDateFormatted) ? "" : total);
     content.push(totalTemplate);
 
     return content;


### PR DESCRIPTION
**Description**

- Fix poll total parsing.
- Only include poll total if the current date is equal to or after the poll end date.