### PR TITLE
[#82] Gracefully handle news post category fetching failures

### DIFF
--- a/.changeset/famous-windows-grin.md
+++ b/.changeset/famous-windows-grin.md
@@ -1,0 +1,5 @@
+---
+"osrs-web-scraper": patch
+---
+
+Gracefully handle news post category fetching failures

--- a/src/scrapers/news/sections/newsHeader/newsHeader.ts
+++ b/src/scrapers/news/sections/newsHeader/newsHeader.ts
@@ -12,6 +12,7 @@ import Parser from "rss-parser";
 
 import {
   NEWS_RSS_LINK,
+  getLatestRSSCateogry,
   getNewsCategory,
   getNewsUrlIdentifier,
 } from "./newsHeader.utils";
@@ -24,12 +25,8 @@ import { NewsSection } from "../types";
 
 const newsHeader: NewsSection = {
   format: async (html, url, title) => {
-    const rss = await new Parser().parseURL(NEWS_RSS_LINK);
-    const urlIdentifier = getNewsUrlIdentifier(url);
-    const item = rss.items.find(
-      (item) => getNewsUrlIdentifier(item.link) === urlIdentifier
-    );
-    const category = getNewsCategory(item?.categories?.[0] ?? "");
+    const rssCategory = await getLatestRSSCateogry(url);
+    const category = getNewsCategory(rssCategory ?? "");
 
     const headerRoot = parse(html);
 

--- a/src/scrapers/news/sections/newsHeader/newsHeader.utils.ts
+++ b/src/scrapers/news/sections/newsHeader/newsHeader.utils.ts
@@ -1,3 +1,5 @@
+import Parser from "rss-parser";
+
 export const NEWS_RSS_LINK =
   "https://secure.runescape.com/m=news/a=1/latest_news.rss?oldschool=true";
 
@@ -49,6 +51,19 @@ const updateCategories: { [key: string]: NewsCategory } = {
   "Website update": "website",
   "Your Feedback updates": "yourfeedback",
   "Your Feedback": "yourfeedback",
+};
+
+export const getLatestRSSCateogry = async (url: string) => {
+  try {
+    const rss = await new Parser().parseURL(NEWS_RSS_LINK);
+    const urlIdentifier = getNewsUrlIdentifier(url);
+    const item = rss?.items?.find(
+      (item) => getNewsUrlIdentifier(item?.link) === urlIdentifier
+    );
+    return item?.categories?.[0];
+  } catch (error) {
+    return undefined;
+  }
 };
 
 export const getNewsCategory = (rawCategory: string) =>


### PR DESCRIPTION
**Description**
Prevent the news post scraper from failing if the RSS feed link fails to load or fails to obtain a news post category.