### PR TITLE
[#95] Fix table header parsing

### DIFF
--- a/.changeset/afraid-gifts-act.md
+++ b/.changeset/afraid-gifts-act.md
@@ -1,0 +1,5 @@
+---
+"osrs-web-scraper": patch
+---
+
+Re-order table option params

--- a/.changeset/five-numbers-repeat.md
+++ b/.changeset/five-numbers-repeat.md
@@ -1,0 +1,5 @@
+---
+"osrs-web-scraper": patch
+---
+
+Add support to table parser for parsing thead

--- a/src/scrapers/news/sections/newsContent/nodes/__tests__/__snapshots__/table.test.ts.snap
+++ b/src/scrapers/news/sections/newsContent/nodes/__tests__/__snapshots__/table.test.ts.snap
@@ -1,10 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`table node A basic table should render 1`] = `
-"{| style=\\"text-align: center;\\" class=\\"wikitable\\"
+exports[`table node A table with no thead should render 1`] = `
+"{| class=\\"wikitable\\" style=\\"text-align: center;\\"
 |-
-! test
-! test
+! header1
+! header2
+|-
+| test
+| test
+|}"
+`;
+
+exports[`table node A table with thead should render 1`] = `
+"{| class=\\"wikitable\\" style=\\"text-align: center;\\"
+|-
+! header1
+! header2
+|-
+| test
+| test
 |-
 | test
 | test

--- a/src/scrapers/news/sections/newsContent/nodes/__tests__/table.test.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/__tests__/table.test.ts
@@ -4,9 +4,18 @@ import parse from "node-html-parser";
 import tableParser from "../table";
 
 describe("table node", () => {
-  test("A basic table should render", () => {
+  test("A table with no thead should render", () => {
     const root = parse(
-      "<table><tbody><tr><td>test</td><td>test</td></tr><tr><td>test</td><td>test</td></tr></tbody></table>"
+      "<table><tbody><tr><td>header1</td><td>header2</td></tr><tr><td>test</td><td>test</td></tr></tbody></table>"
+    );
+    const builder = new MediaWikiBuilder();
+    builder.addContents([tableParser(root.firstChild)].flat());
+    expect(builder.build()).toMatchSnapshot();
+  });
+
+  test("A table with thead should render", () => {
+    const root = parse(
+      "<table><thead><tr><td>header1</td><td>header2</td></tr></thead><tbody><tr><td>test</td><td>test</td></tr><tr><td>test</td><td>test</td></tr></tbody></table>"
     );
     const builder = new MediaWikiBuilder();
     builder.addContents([tableParser(root.firstChild)].flat());

--- a/src/scrapers/news/sections/newsContent/nodes/table.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/table.ts
@@ -12,9 +12,13 @@ import { ContentNodeParser } from "../types";
 export const tableParser: ContentNodeParser = (node, options) => {
   if (node instanceof HTMLElement) {
     const table = node as HTMLElement;
+    const thead = table.querySelector("thead");
     const tbody = table.querySelector("tbody");
     const rowNodes = tbody.querySelectorAll("tr");
-    const headerRowNodes = rowNodes.shift().querySelectorAll("td");
+    const headerNodes = thead?.querySelectorAll("tr") ?? [];
+    const headerRowNodes = (headerNodes?.length > 0 ? headerNodes : rowNodes)
+      .shift()
+      .querySelectorAll("td");
     const headers: MediaWikiTableCell[] =
       headerRowNodes.map<MediaWikiTableCell>((node) => ({
         content: [new MediaWikiText(node.textContent.trim())],
@@ -39,8 +43,8 @@ export const tableParser: ContentNodeParser = (node, options) => {
 
     return new MediaWikiTable({
       options: {
-        style: "text-align: center;",
         class: "wikitable",
+        style: "text-align: center;",
       },
       rows: [
         {


### PR DESCRIPTION
**Description**
This PR adds support for parsing `thead` in `table` html elements.