### PR TITLE
Add cache option to github actions

### DIFF
--- a/.changeset/lucky-rabbits-kiss.md
+++ b/.changeset/lucky-rabbits-kiss.md
@@ -1,0 +1,5 @@
+---
+"osrs-web-scraper": patch
+---
+
+Add cache option to github actions

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -15,8 +15,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
+          cache: yarn
           node-version: 16.x
 
       - name: Install dependencies

--- a/.github/workflows/workflow-dispatch.yml
+++ b/.github/workflows/workflow-dispatch.yml
@@ -19,8 +19,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
+          cache: yarn
           node-version: 16.x
 
       - name: Install dependencies


### PR DESCRIPTION
**Description**
Add the `cache` option to `setup-node` steps for speeding up workflows.