### PR TITLE
[#38] Add support for parsing image node width

### DIFF
--- a/.changeset/nervous-spies-press.md
+++ b/.changeset/nervous-spies-press.md
@@ -1,0 +1,5 @@
+---
+"osrs-web-scraper": patch
+---
+
+Add support for parsing image node width

--- a/src/scrapers/news/sections/newsContent/nodes/__tests__/__snapshots__/image.test.ts.snap
+++ b/src/scrapers/news/sections/newsContent/nodes/__tests__/__snapshots__/image.test.ts.snap
@@ -1,0 +1,6 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`image node Image node should parse and render 1`] = `
+"[[File:test-title (1).png|200px]]
+"
+`;

--- a/src/scrapers/news/sections/newsContent/nodes/__tests__/image.test.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/__tests__/image.test.ts
@@ -1,0 +1,27 @@
+import { MediaWikiBuilder } from "@osrs-wiki/mediawiki-builder";
+import fs from "fs";
+import parse from "node-html-parser";
+
+import imageParser from "../image";
+
+describe("image node", () => {
+  test("Image node should parse and render", () => {
+    const existsSyncSpy = jest.spyOn(fs, "existsSync");
+    const mkdirSyncSpy = jest.spyOn(fs, "mkdirSync");
+
+    const root = parse(
+      '<image href="https://test.com/image.png" width="200" />'
+    );
+
+    const builder = new MediaWikiBuilder();
+    builder.addContents(
+      [imageParser(root.firstChild, { title: "test-title" })].flat()
+    );
+    expect(builder.build()).toMatchSnapshot();
+
+    expect(existsSyncSpy).toHaveBeenCalledWith(`./out/news/test-title`);
+    expect(mkdirSyncSpy).toHaveBeenCalledWith(`./out/news/test-title`, {
+      recursive: true,
+    });
+  });
+});

--- a/src/scrapers/news/sections/newsContent/nodes/image.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/image.ts
@@ -40,11 +40,17 @@ export const imageParser: ContentNodeParser = (
     const imagePath = `${imageDirectory}/${imageName}.${imageExtension}`;
     let dimensions;
     try {
-      if (
-        imageExtensions.includes(imageExtension) &&
-        fs.existsSync(imagePath)
-      ) {
-        dimensions = sizeOf(`${imageDirectory}/${imageName}.${imageExtension}`);
+      if (image.attributes.width) {
+        dimensions = { width: parseInt(image.attributes.width) };
+      } else {
+        if (
+          imageExtensions.includes(imageExtension) &&
+          fs.existsSync(imagePath)
+        ) {
+          dimensions = sizeOf(
+            `${imageDirectory}/${imageName}.${imageExtension}`
+          );
+        }
       }
     } catch (error) {
       console.error(


### PR DESCRIPTION
**Description**
Image nodes were using `sizeOf` even in cases where the image node had the width defined. This PR adds support for prioritizing image node width over using `sizeOf`, when the attribute exists. It also adds a snapshot test for image nodes.