### PR TITLE
Fix start:node command

### DIFF
--- a/.changeset/tidy-bottles-explain.md
+++ b/.changeset/tidy-bottles-explain.md
@@ -1,0 +1,5 @@
+---
+"osrs-web-scraper": patch
+---
+
+Fix start:node command

--- a/.github/workflows/workflow-dispatch.yml
+++ b/.github/workflows/workflow-dispatch.yml
@@ -1,4 +1,4 @@
-name: Run News Scraper
+name: Run OSRS Web Scraper
 
 on:
   workflow_dispatch:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "prettier": "prettier \"src/**/*.{js,ts}\"",
     "prettier:fix": "yarn prettier --write",
     "start": "nodemon -r tsconfig-paths/register ./src/index.ts",
-    "start:node": "node -r typescript-transform-paths/register ./dist/index.js",
+    "start:node": "node -r typescript-transform-paths/register ./dist/src/index.js",
     "test": "cross-env NODE_ENV=test DOTENV_CONFIG_PATH=.env.test jest --passWithNoTests",
     "release": "changeset publish",
     "prepare": "husky install && ts-patch install -s"


### PR DESCRIPTION
**Description**
Fix the `start:node` command referencing the correct build path.