### PR TITLE
[#155] Add support for sup and sub html tags

### DIFF
--- a/.changeset/flat-squids-care.md
+++ b/.changeset/flat-squids-care.md
@@ -1,0 +1,5 @@
+---
+"osrs-web-scraper": minor
+---
+
+Add support for sup and sub hmtl tags

--- a/src/scrapers/news/sections/newsContent/nodes/__tests__/__snapshots__/html.test.ts.snap
+++ b/src/scrapers/news/sections/newsContent/nodes/__tests__/__snapshots__/html.test.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`html node Tag should parse and render MediaWikiHTML 1`] = `"<sub>test</sub>"`;

--- a/src/scrapers/news/sections/newsContent/nodes/__tests__/html.test.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/__tests__/html.test.ts
@@ -1,0 +1,13 @@
+import { MediaWikiBuilder } from "@osrs-wiki/mediawiki-builder";
+import parse from "node-html-parser";
+
+import htmlParser from "../html";
+
+describe("html node", () => {
+  test("Tag should parse and render MediaWikiHTML", () => {
+    const root = parse("<sub>test</sub>");
+    const builder = new MediaWikiBuilder();
+    builder.addContents([htmlParser(root.firstChild)].flat());
+    expect(builder.build()).toMatchSnapshot();
+  });
+});

--- a/src/scrapers/news/sections/newsContent/nodes/html.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/html.ts
@@ -1,0 +1,25 @@
+import { MediaWikiContent, MediaWikiHTML } from "@osrs-wiki/mediawiki-builder";
+import { HTMLElement } from "node-html-parser";
+
+import textParser from "./text";
+import { ContentNodeParser } from "../types";
+
+export const htmlParser: ContentNodeParser = (node, options) => {
+  let childrenContent: MediaWikiContent[] = [];
+  const children = textParser(node, options);
+  childrenContent = Array.isArray(children) ? children : [children];
+  let htmlNode: MediaWikiContent[] = undefined;
+  if (node instanceof HTMLElement) {
+    htmlNode = [
+      new MediaWikiHTML(
+        node.tagName?.toLocaleLowerCase(),
+        childrenContent,
+        {},
+        { collapsed: true }
+      ),
+    ];
+  }
+  return htmlNode;
+};
+
+export default htmlParser;

--- a/src/scrapers/news/sections/newsContent/nodes/parser.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/parser.ts
@@ -7,6 +7,7 @@ import centerParser from "./center";
 import detailsParser from "./details";
 import divParser from "./div";
 import fontParser from "./font";
+import htmlParser from "./html";
 import iframeParser from "./iframe";
 import imageParser from "./image";
 import italicsParser from "./italics";
@@ -37,6 +38,8 @@ const nodeParserMap: { [key: string]: ContentNodeParser } = {
   li: listItemParser,
   ol: listParser,
   p: paragraphParser,
+  sub: htmlParser,
+  sup: htmlParser,
   span: spanParser,
   strong: boldParser,
   table: tableParser,


### PR DESCRIPTION
**Description**
Add support for `sub` and `sup` html tags parsing to `MediaWikiHTML`.