### PR TITLE
Fix iframe crashing error

### DIFF
--- a/.changeset/swift-walls-drum.md
+++ b/.changeset/swift-walls-drum.md
@@ -1,0 +1,5 @@
+---
+"osrs-web-scraper": patch
+---
+
+Add support for pulling iframe link from src attribute

--- a/src/scrapers/news/sections/newsContent/nodes/__tests__/__snapshots__/iframe.test.ts.snap
+++ b/src/scrapers/news/sections/newsContent/nodes/__tests__/__snapshots__/iframe.test.ts.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`iframe node iframe link should be parsed from src attribute 1`] = `"<center><big>[https://example.com title]</big></center>"`;
+
 exports[`iframe node iframe with non-youtube link should use center tag 1`] = `"<center><big>[https://example.com title]</big></center>"`;
 
 exports[`iframe node iframe with youtube link should use Youtube template 1`] = `

--- a/src/scrapers/news/sections/newsContent/nodes/__tests__/iframe.test.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/__tests__/iframe.test.ts
@@ -21,4 +21,11 @@ describe("iframe node", () => {
     builder.addContents([iframeParser(root.firstChild)].flat());
     expect(builder.build()).toMatchSnapshot();
   });
+
+  test("iframe link should be parsed from src attribute", () => {
+    const root = parse('<iframe src="https://example.com">blah</iframe>');
+    const builder = new MediaWikiBuilder();
+    builder.addContents([iframeParser(root.firstChild)].flat());
+    expect(builder.build()).toMatchSnapshot();
+  });
 });

--- a/src/scrapers/news/sections/newsContent/nodes/iframe.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/iframe.ts
@@ -9,8 +9,9 @@ import { ContentNodeParser } from "../types";
 
 export const iframeParser: ContentNodeParser = (node) => {
   const htmlNode = node as HTMLElement;
-  const link = htmlNode.attributes["data-cookieblock-src"];
-  const videoId = link.includes("youtube.com") && link?.split("embed/")?.pop();
+  const link =
+    htmlNode.attributes["data-cookieblock-src"] ?? htmlNode.attributes["src"];
+  const videoId = link?.includes("youtube.com") && link?.split("embed/")?.pop();
   if (videoId) {
     const youtubeTemplate = new MediaWikiTemplate("Youtube", {
       collapsed: true,


### PR DESCRIPTION
**Description**
Fix the issue that is observed here: https://github.com/osrs-wiki/osrs-web-scraper/actions/runs/11501255481/job/32013425935#step:6:23

Also fallback on iframe src attribute if `data-cookieblock-src` is undefined.