### PR TITLE
[#191] Add Youtube playlist support to iframe parser

### DIFF
--- a/.changeset/plenty-colts-compete.md
+++ b/.changeset/plenty-colts-compete.md
@@ -1,0 +1,5 @@
+---
+"osrs-web-scraper": minor
+---
+
+Add Youtube playlist support to iframe parser

--- a/src/scrapers/news/sections/newsContent/nodes/__tests__/__snapshots__/iframe.test.ts.snap
+++ b/src/scrapers/news/sections/newsContent/nodes/__tests__/__snapshots__/iframe.test.ts.snap
@@ -8,3 +8,8 @@ exports[`iframe node iframe with youtube link should use Youtube template 1`] = 
 "{{Youtube|test}}
 "
 `;
+
+exports[`iframe node iframe with youtube playlist link should use Youtube template with type=playlist 1`] = `
+"{{Youtube|type=playlist|PLRs68iqW7gYvSyTqu12WFMMXYZM-2regV}}
+"
+`;

--- a/src/scrapers/news/sections/newsContent/nodes/__tests__/iframe.test.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/__tests__/iframe.test.ts
@@ -13,6 +13,15 @@ describe("iframe node", () => {
     expect(builder.build()).toMatchSnapshot();
   });
 
+  test("iframe with youtube playlist link should use Youtube template with type=playlist", () => {
+    const root = parse(
+      '<iframe data-cookieblock-src="https://www.youtube.com/embed/videoseries?si=rh-lb4jty9OTAKAM&list=PLRs68iqW7gYvSyTqu12WFMMXYZM-2regV">blah</iframe>'
+    );
+    const builder = new MediaWikiBuilder();
+    builder.addContents([iframeParser(root.firstChild)].flat());
+    expect(builder.build()).toMatchSnapshot();
+  });
+
   test("iframe with non-youtube link should use center tag", () => {
     const root = parse(
       '<iframe data-cookieblock-src="https://example.com">blah</iframe>'

--- a/src/scrapers/news/sections/newsContent/nodes/iframe.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/iframe.ts
@@ -4,6 +4,7 @@ import {
   MediaWikiTemplate,
 } from "@osrs-wiki/mediawiki-builder";
 import { HTMLElement } from "node-html-parser";
+import { URL } from "node:url";
 
 import { ContentNodeParser } from "../types";
 
@@ -11,14 +12,29 @@ export const iframeParser: ContentNodeParser = (node) => {
   const htmlNode = node as HTMLElement;
   const link =
     htmlNode.attributes["data-cookieblock-src"] ?? htmlNode.attributes["src"];
-  const videoId = link?.includes("youtube.com") && link?.split("embed/")?.pop();
-  if (videoId) {
-    const youtubeTemplate = new MediaWikiTemplate("Youtube", {
-      collapsed: true,
-    });
-    youtubeTemplate.add("", videoId);
+  const parsedUrl = new URL(link);
+  if (parsedUrl.hostname.includes("youtube.com")) {
+    if (parsedUrl.pathname.includes("videoseries")) {
+      const playlistId = parsedUrl.searchParams.get("list");
+      if (playlistId) {
+        const youtubeTemplate = new MediaWikiTemplate("Youtube", {
+          collapsed: true,
+        });
+        youtubeTemplate.add("type", "playlist");
+        youtubeTemplate.add("", playlistId);
+        return youtubeTemplate;
+      }
+    } else {
+      const videoId = link?.split("embed/")?.pop()?.split("?")?.[0];
+      if (videoId) {
+        const youtubeTemplate = new MediaWikiTemplate("Youtube", {
+          collapsed: true,
+        });
+        youtubeTemplate.add("", videoId);
 
-    return youtubeTemplate;
+        return youtubeTemplate;
+      }
+    }
   }
   return new MediaWikiHTML(
     "center",


### PR DESCRIPTION
**Description**
Resolves #191 
Support the `playlist` param in the `Youtube` template creation in the iframe parser.