### PR TITLE
fix: Fix YouTube video caption parsing

### DIFF
--- a/.changeset/all-meals-mate.md
+++ b/.changeset/all-meals-mate.md
@@ -1,0 +1,5 @@
+---
+"osrs-web-scraper": patch
+---
+
+Fix div and youtubeTransformer parsing for YouTube video captions

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osrs-web-scraper",
-  "version": "0.27.2",
+  "version": "0.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osrs-web-scraper",
-      "version": "0.27.2",
+      "version": "0.26.0",
       "license": "ISC",
       "dependencies": {
         "@osrs-wiki/mediawiki-builder": "^1.9.0",
@@ -837,6 +837,18 @@
         }
       }
     },
+    "node_modules/@changesets/cli/node_modules/@types/node": {
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
+      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
+    },
     "node_modules/@changesets/cli/node_modules/semver": {
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
@@ -1020,6 +1032,34 @@
         "fs-extra": "^7.0.1",
         "human-id": "^4.1.1",
         "prettier": "^2.7.1"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2161,6 +2201,42 @@
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
       "license": "MIT"
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.1.19",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.19.tgz",
@@ -2730,6 +2806,18 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
@@ -2846,6 +2934,15 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -3628,6 +3725,15 @@
         "safe-buffer": "~5.1.1"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/cross-env": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
@@ -3864,6 +3970,18 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1367902.tgz",
       "integrity": "sha512-XxtPuC3PGakY6PD7dG66/o8KwJ/LkH2/EKe19Dcw58w53dv4/vSQEkn/SzuyhHE2q4zPgCkxQBxus3VV4ql+Pg==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/diff-sequences": {
       "version": "28.1.1",
@@ -8051,6 +8169,20 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/puppeteer/node_modules/typescript": {
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/quansync": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
@@ -9090,6 +9222,52 @@
         "node": ">=12"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ts-patch": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-patch/-/ts-patch-2.1.0.tgz",
@@ -9323,6 +9501,15 @@
         "through": "^2.3.8"
       }
     },
+    "node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -9342,6 +9529,15 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.0.1",
@@ -9583,6 +9779,18 @@
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osrs-web-scraper",
-  "version": "0.26.0",
+  "version": "0.27.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osrs-web-scraper",
-      "version": "0.26.0",
+      "version": "0.27.2",
       "license": "ISC",
       "dependencies": {
         "@osrs-wiki/mediawiki-builder": "^1.9.0",
@@ -837,18 +837,6 @@
         }
       }
     },
-    "node_modules/@changesets/cli/node_modules/@types/node": {
-      "version": "24.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
-      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.10.0"
-      }
-    },
     "node_modules/@changesets/cli/node_modules/semver": {
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
@@ -1032,34 +1020,6 @@
         "fs-extra": "^7.0.1",
         "human-id": "^4.1.1",
         "prettier": "^2.7.1"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2201,42 +2161,6 @@
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
       "license": "MIT"
     },
-    "node_modules/@tsconfig/node10": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@tsconfig/node12": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@tsconfig/node14": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@tsconfig/node16": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@types/babel__core": {
       "version": "7.1.19",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.19.tgz",
@@ -2806,18 +2730,6 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/acorn-walk": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/agent-base": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
@@ -2934,15 +2846,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -3725,15 +3628,6 @@
         "safe-buffer": "~5.1.1"
       }
     },
-    "node_modules/create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/cross-env": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
@@ -3970,18 +3864,6 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1367902.tgz",
       "integrity": "sha512-XxtPuC3PGakY6PD7dG66/o8KwJ/LkH2/EKe19Dcw58w53dv4/vSQEkn/SzuyhHE2q4zPgCkxQBxus3VV4ql+Pg==",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.3.1"
-      }
     },
     "node_modules/diff-sequences": {
       "version": "28.1.1",
@@ -8169,20 +8051,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/puppeteer/node_modules/typescript": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/quansync": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
@@ -9222,52 +9090,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/ts-node": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/ts-patch": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-patch/-/ts-patch-2.1.0.tgz",
@@ -9501,15 +9323,6 @@
         "through": "^2.3.8"
       }
     },
-    "node_modules/undici-types": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
-      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -9529,15 +9342,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.0.1",
@@ -9779,18 +9583,6 @@
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
-      }
-    },
-    "node_modules/yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/src/scrapers/news/sections/newsContent/nodes/__tests__/__snapshots__/div.test.ts.snap
+++ b/src/scrapers/news/sections/newsContent/nodes/__tests__/__snapshots__/div.test.ts.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`div node osrs-embed__fallback class should preserve text around link 1`] = `"If you can't see the embedded content above, [https://www.youtube.com/embed/5PwrxOzH5P4?si=0G50ueNJQugoBmpb click here]."`;
+
 exports[`div node osrs-subheading class should parse as level 4 header 1`] = `
 "====Subheading Text====
 "

--- a/src/scrapers/news/sections/newsContent/nodes/__tests__/div.test.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/__tests__/div.test.ts
@@ -74,4 +74,13 @@ describe("div node", () => {
     builder.addContents([divParser(root.firstChild)].flat());
     expect(builder.build()).toMatchSnapshot();
   });
+
+  test("osrs-embed__fallback class should preserve text around link", () => {
+    const root = parse(
+      '<div class="osrs-embed__fallback">If you can\'t see the embedded content above, <a href="https://www.youtube.com/embed/5PwrxOzH5P4?si=0G50ueNJQugoBmpb">click here</a>.</div>'
+    );
+    const builder = new MediaWikiBuilder();
+    builder.addContents([divParser(root.firstChild)].flat());
+    expect(builder.build()).toMatchSnapshot();
+  });
 });

--- a/src/scrapers/news/sections/newsContent/nodes/__tests__/div.test.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/__tests__/div.test.ts
@@ -39,9 +39,11 @@ describe("div node", () => {
     expect(result).toBeDefined();
     // The result should be a gallery parser result with the tag "gallery"
     expect(result).toEqual(
-      expect.objectContaining({
-        tag: "gallery",
-      })
+      expect.arrayContaining([
+        expect.objectContaining({
+          tag: "gallery",
+        }),
+      ])
     );
   });
 

--- a/src/scrapers/news/sections/newsContent/nodes/__tests__/pollBox.test.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/__tests__/pollBox.test.ts
@@ -92,4 +92,17 @@ describe("pollBox", () => {
 
     expect(builder.build()).toContain("File:test-title");
   });
+
+  test("poll-box preserves youtube fallback caption text", () => {
+    const root = parse(
+      '<div class="poll-box"><div class="osrs-embed osrs-embed--video" data-src="https://www.youtube.com/embed/5PwrxOzH5P4?si=0G50ueNJQugoBmpb" data-fallback="https://www.youtube.com/embed/5PwrxOzH5P4?si=0G50ueNJQugoBmpb"><div class="osrs-embed__frame"><iframe src="https://www.youtube.com/embed/5PwrxOzH5P4?si=0G50ueNJQugoBmpb"></iframe></div></div><div class="osrs-embed__fallback">If you can\'t see the embedded content above, <a href="https://www.youtube.com/embed/5PwrxOzH5P4?si=0G50ueNJQugoBmpb">click here</a>.</div><p>Follow-up text outside centered caption.</p></div>'
+    );
+    const builder = new MediaWikiBuilder();
+    builder.addContents([pollBoxParser(root.firstChild)].flat());
+    const result = builder.build();
+
+    expect(result).toContain("{{Youtube|5PwrxOzH5P4}}");
+    expect(result).toContain("If you can't see the embedded content above");
+    expect(result).toContain("Follow-up text outside centered caption.");
+  });
 });

--- a/src/scrapers/news/sections/newsContent/nodes/div/__tests__/__snapshots__/gallery.test.ts.snap
+++ b/src/scrapers/news/sections/newsContent/nodes/div/__tests__/__snapshots__/gallery.test.ts.snap
@@ -5,6 +5,7 @@ exports[`gallery node Gallery should parse and render 1`] = `
 test-title (1).png
 test-title (2).jpg
 </gallery>
+
 "
 `;
 
@@ -15,5 +16,6 @@ HD & Plugin API Progress Update (2).png
 HD & Plugin API Progress Update (3).png
 HD & Plugin API Progress Update (4).png
 </gallery>
+
 "
 `;

--- a/src/scrapers/news/sections/newsContent/nodes/div/div.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/div/div.ts
@@ -34,7 +34,14 @@ export const divParser: ContentNodeParser = (node, options) => {
     if (parse) {
       return parse(node, options);
     } else if (!ignoredClasses.includes(className)) {
-      return node.childNodes.map((child) => nodeParser(child, options)).flat();
+      return node.childNodes
+        .map((childNode) => {
+          if (childNode instanceof HTMLElement) {
+            return nodeParser(childNode, options);
+          }
+          return textParser(childNode, options);
+        })
+        .flat();
     }
   } else {
     return textParser(node, options);

--- a/src/scrapers/news/sections/newsContent/nodes/div/gallery.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/div/gallery.ts
@@ -1,4 +1,8 @@
-import { MediaWikiHTML, MediaWikiText } from "@osrs-wiki/mediawiki-builder";
+import {
+  MediaWikiBreak,
+  MediaWikiHTML,
+  MediaWikiText,
+} from "@osrs-wiki/mediawiki-builder";
 import fs from "fs";
 import { HTMLElement } from "node-html-parser";
 
@@ -23,24 +27,29 @@ const processBackgroundImageElement = (
 
       const imageName = `${formattedTitle} (${++ContentContext.imageCount})`;
       const imageExtension = getFileExtension(imageUrl);
-      
-      content.push(new MediaWikiText(
-        `${content.length === 0 ? "" : "\n"}${imageName}.${imageExtension}`
-      ));
+
+      content.push(
+        new MediaWikiText(
+          `${content.length === 0 ? "" : "\n"}${imageName}.${imageExtension}`
+        )
+      );
     }
   }
 };
 
 // Handler for slideshow container galleries with background images
-const handleSlideshowGallery = (divElement: HTMLElement, options: { [key: string]: string | boolean | number }): MediaWikiText[] => {
+const handleSlideshowGallery = (
+  divElement: HTMLElement,
+  options: { [key: string]: string | boolean | number }
+): MediaWikiText[] => {
   const content: MediaWikiText[] = [];
   const slides = divElement.querySelectorAll(".mySlides");
   const formattedTitle = formatFileName(options.title as string);
-  
+
   slides.forEach((slide) => {
     const figureElement = slide.querySelector("figure");
     const divisorElement = slide.querySelector("div.divisor");
-    
+
     // Extract background image from figure element (SD version)
     processBackgroundImageElement(figureElement, formattedTitle, content);
 
@@ -52,10 +61,13 @@ const handleSlideshowGallery = (divElement: HTMLElement, options: { [key: string
 };
 
 // Handler for regular galleries with img tags
-const handleRegularGallery = (divElement: HTMLElement, options: { [key: string]: string | boolean | number }): MediaWikiText[] => {
+const handleRegularGallery = (
+  divElement: HTMLElement,
+  options: { [key: string]: string | boolean | number }
+): MediaWikiText[] => {
   const content: MediaWikiText[] = [];
   const imageNodes = divElement.querySelectorAll("img");
-  
+
   imageNodes.forEach((imageNode, index) => {
     const image = imageNode as HTMLElement;
     const imageLink = image.attributes.src;
@@ -69,16 +81,23 @@ const handleRegularGallery = (divElement: HTMLElement, options: { [key: string]:
     const imageName = `${formattedTitle} (${++ContentContext.imageCount})`;
     const imageExtension = getFileExtension(imageLink);
 
-    content.push(new MediaWikiText(
-      `${index === 0 ? "" : "\n"}${imageName}.${imageExtension}`
-    ));
+    content.push(
+      new MediaWikiText(
+        `${index === 0 ? "" : "\n"}${imageName}.${imageExtension}`
+      )
+    );
   });
 
   return content;
 };
 
 // Map of gallery types to their handlers
-const galleryHandlers: { [key: string]: (element: HTMLElement, options: { [key: string]: string | boolean | number }) => MediaWikiText[] } = {
+const galleryHandlers: {
+  [key: string]: (
+    element: HTMLElement,
+    options: { [key: string]: string | boolean | number }
+  ) => MediaWikiText[];
+} = {
   "slideshow-container": handleSlideshowGallery,
   "default": handleRegularGallery,
 };
@@ -86,21 +105,27 @@ const galleryHandlers: { [key: string]: (element: HTMLElement, options: { [key: 
 export const galleryParser: ContentNodeParser = (node, options) => {
   if (node instanceof HTMLElement && node.childNodes.length > 0) {
     const divElement = node as HTMLElement;
-    
+
     // Determine gallery type and use appropriate handler
     let galleryType = "default";
-    if (divElement.id === "slideshow-container" || divElement.classList.contains("slideshow-container")) {
+    if (
+      divElement.id === "slideshow-container" ||
+      divElement.classList.contains("slideshow-container")
+    ) {
       galleryType = "slideshow-container";
     }
-    
+
     const handler = galleryHandlers[galleryType];
     const content = handler(divElement, options);
 
-    return new MediaWikiHTML("gallery", content, {
-      mode: "packed",
-      heights: "180",
-      style: "text-align:center",
-    });
+    return [
+      new MediaWikiHTML("gallery", content, {
+        mode: "packed",
+        heights: "180",
+        style: "text-align:center",
+      }),
+      new MediaWikiBreak(),
+    ];
   }
 };
 

--- a/src/scrapers/news/sections/newsContent/nodes/div/pollBox.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/div/pollBox.ts
@@ -27,8 +27,7 @@ export const pollBoxParser: ContentNodeParser = (node, options) => {
     const isPollQuestion =
       childNodes.some((child) =>
         child.textContent?.match(/Question\s*#?[\dX]*\s*:?/i)
-      ) ||
-      divElement.textContent?.match(/Question\s*#?[\dX]*\s*:?/i);
+      ) || divElement.textContent?.match(/Question\s*#?[\dX]*\s*:?/i);
 
     if (isPollQuestion) {
       let parsedNumber;

--- a/src/scrapers/news/transformers/__tests__/__snapshots__/youtubeTransformer.test.ts.snap
+++ b/src/scrapers/news/transformers/__tests__/__snapshots__/youtubeTransformer.test.ts.snap
@@ -20,6 +20,14 @@ exports[`NewsYoutubeTransformer should wrap YouTube playlist template in center 
 "
 `;
 
+exports[`NewsYoutubeTransformer should wrap YouTube template with a text/link/text fallback caption in center tags 1`] = `
+"<center>
+{{Youtube|5PwrxOzH5P4}}
+If you can't see the embedded content above, [https://www.youtube.com/embed/5PwrxOzH5P4?si=0G50ueNJQugoBmpb click here].
+</center>
+"
+`;
+
 exports[`NewsYoutubeTransformer should wrap YouTube template with caption inside paragraph (from HTML <p><i>) 1`] = `
 "<center>
 {{Youtube|-0e4IyRtPwY}}

--- a/src/scrapers/news/transformers/__tests__/youtubeTransformer.test.ts
+++ b/src/scrapers/news/transformers/__tests__/youtubeTransformer.test.ts
@@ -2,6 +2,7 @@ import {
   MediaWikiBreak,
   MediaWikiBuilder,
   MediaWikiContent,
+  MediaWikiExternalLink,
   MediaWikiTemplate,
   MediaWikiText,
 } from "@osrs-wiki/mediawiki-builder";
@@ -16,9 +17,9 @@ describe("NewsYoutubeTransformer", () => {
     youtubeTemplate.add("", "ZNePfBmCZbM");
 
     const originalContent: MediaWikiContent[] = [youtubeTemplate];
-    
+
     const transformed = new NewsYoutubeTransformer().transform(originalContent);
-    
+
     expect(
       new MediaWikiBuilder().addContents(transformed).build()
     ).toMatchSnapshot();
@@ -37,9 +38,9 @@ describe("NewsYoutubeTransformer", () => {
         "If you can't see the fantastic video by [https://x.com/_amentos Amentos] above, [https://www.youtube.com/watch?v=ZNePfBmCZbM click here]."
       ),
     ];
-    
+
     const transformed = new NewsYoutubeTransformer().transform(originalContent);
-    
+
     expect(
       new MediaWikiBuilder().addContents(transformed).build()
     ).toMatchSnapshot();
@@ -53,9 +54,9 @@ describe("NewsYoutubeTransformer", () => {
     youtubeTemplate.add("", "PLRs68iqW7gYvSyTqu12WFMMXYZM-2regV");
 
     const originalContent: MediaWikiContent[] = [youtubeTemplate];
-    
+
     const transformed = new NewsYoutubeTransformer().transform(originalContent);
-    
+
     expect(
       new MediaWikiBuilder().addContents(transformed).build()
     ).toMatchSnapshot();
@@ -72,9 +73,9 @@ describe("NewsYoutubeTransformer", () => {
       new MediaWikiBreak(),
       new MediaWikiText("Some text"),
     ];
-    
+
     const transformed = new NewsYoutubeTransformer().transform(originalContent);
-    
+
     expect(transformed).toEqual(originalContent);
   });
 
@@ -96,9 +97,9 @@ describe("NewsYoutubeTransformer", () => {
       otherTemplate,
       new MediaWikiText("Text after"),
     ];
-    
+
     const transformed = new NewsYoutubeTransformer().transform(originalContent);
-    
+
     expect(
       new MediaWikiBuilder().addContents(transformed).build()
     ).toMatchSnapshot();
@@ -112,33 +113,73 @@ describe("NewsYoutubeTransformer", () => {
 
     // This simulates what happens when parsing <p><i>caption</i></p>
     // The paragraph parser creates a MediaWikiText with the italic text and a break as children
-    const paragraphText = new MediaWikiText([
-      new MediaWikiText("If you can't see the video above, click ", { italics: true }),
-      new MediaWikiText("[https://www.youtube.com/watch?v=-0e4IyRtPwY here]", { italics: true }),
-      new MediaWikiText("!", { italics: true }),
-      new MediaWikiBreak(),
-    ], { italics: true });
+    const paragraphText = new MediaWikiText(
+      [
+        new MediaWikiText("If you can't see the video above, click ", {
+          italics: true,
+        }),
+        new MediaWikiText(
+          "[https://www.youtube.com/watch?v=-0e4IyRtPwY here]",
+          { italics: true }
+        ),
+        new MediaWikiText("!", { italics: true }),
+        new MediaWikiBreak(),
+      ],
+      { italics: true }
+    );
 
     const originalContent: MediaWikiContent[] = [
       youtubeTemplate,
       paragraphText,
     ];
-    
+
     const transformed = new NewsYoutubeTransformer().transform(originalContent);
-    
+
     const result = new MediaWikiBuilder().addContents(transformed).build();
-    
+
     // The caption should be inside the center tags, not outside
     expect(result).toContain("<center>");
     expect(result).toContain("{{Youtube|-0e4IyRtPwY}}");
     expect(result).toContain("If you can't see the video above");
     expect(result).toContain("</center>");
-    
+
     // Check that caption comes before closing center tag
     const centerCloseIndex = result.indexOf("</center>");
     const captionIndex = result.indexOf("If you can't see the video above");
     expect(captionIndex).toBeLessThan(centerCloseIndex);
-    
+
+    expect(result).toMatchSnapshot();
+  });
+
+  it("should wrap YouTube template with a text/link/text fallback caption in center tags", () => {
+    // This simulates the parsed output of:
+    // <div class="osrs-embed__fallback">If you can't see the embedded content
+    // above, <a href="...">click here</a>.</div>
+    const youtubeTemplate = new MediaWikiTemplate("Youtube", {
+      collapsed: true,
+    });
+    youtubeTemplate.add("", "5PwrxOzH5P4");
+
+    const originalContent: MediaWikiContent[] = [
+      youtubeTemplate,
+      new MediaWikiText("If you can't see the embedded content above, "),
+      new MediaWikiExternalLink(
+        "click here",
+        "https://www.youtube.com/embed/5PwrxOzH5P4?si=0G50ueNJQugoBmpb"
+      ),
+      new MediaWikiText("."),
+    ];
+
+    const transformed = new NewsYoutubeTransformer().transform(originalContent);
+    const result = new MediaWikiBuilder().addContents(transformed).build();
+
+    expect(result).toContain("<center>");
+    expect(result).toContain("{{Youtube|5PwrxOzH5P4}}");
+    expect(result).toContain(
+      "If you can't see the embedded content above, [https://www.youtube.com/embed/5PwrxOzH5P4?si=0G50ueNJQugoBmpb click here]."
+    );
+    expect(result).toContain("</center>");
+
     expect(result).toMatchSnapshot();
   });
 });

--- a/src/scrapers/news/transformers/youtubeTransformer.ts
+++ b/src/scrapers/news/transformers/youtubeTransformer.ts
@@ -1,6 +1,7 @@
 import {
   MediaWikiBreak,
   MediaWikiContent,
+  MediaWikiExternalLink,
   MediaWikiHTML,
   MediaWikiTemplate,
   MediaWikiText,
@@ -16,18 +17,46 @@ class NewsYoutubeTransformer extends MediaWikiTransformer {
       const transformedContent = [];
       for (let index = 0; index < content.length; index++) {
         const current = content[index];
-        
+
         // Check if current item is a YouTube template
-        if (current instanceof MediaWikiTemplate && current.name === "Youtube") {
+        if (
+          current instanceof MediaWikiTemplate &&
+          current.name === "Youtube"
+        ) {
           // Check if there's a following caption
           // Pattern 1: break + text (original pattern)
-          const nextBreak = index + 1 < content.length ? content[index + 1] : null;
-          const nextText = index + 2 < content.length ? content[index + 2] : null;
-          
+          const nextBreak =
+            index + 1 < content.length ? content[index + 1] : null;
+          const nextText =
+            index + 2 < content.length ? content[index + 2] : null;
+
           // Pattern 2: text only (from paragraph wrapping)
-          const nextItem = index + 1 < content.length ? content[index + 1] : null;
-          
+          const nextItem =
+            index + 1 < content.length ? content[index + 1] : null;
+
+          // Pattern 3: text + external link + text (from fallback caption divs,
+          // e.g. "If you can't see the embedded content above, <a>click here</a>.")
+          const nextItem2 =
+            index + 2 < content.length ? content[index + 2] : null;
+          const nextItem3 =
+            index + 3 < content.length ? content[index + 3] : null;
+
           if (
+            nextItem instanceof MediaWikiText &&
+            nextItem2 instanceof MediaWikiExternalLink &&
+            nextItem3 instanceof MediaWikiText
+          ) {
+            // Pattern 3: Wrap YouTube template and the text/link/text caption in center tags
+            transformedContent.push(
+              new MediaWikiHTML(
+                "center",
+                [current, nextItem, nextItem2, nextItem3],
+                {},
+                { collapsed: false }
+              )
+            );
+            index += 3; // Skip the caption pieces we just processed
+          } else if (
             nextBreak instanceof MediaWikiBreak &&
             nextText instanceof MediaWikiText
           ) {
@@ -55,12 +84,7 @@ class NewsYoutubeTransformer extends MediaWikiTransformer {
           } else {
             // Just wrap the YouTube template in center tags
             transformedContent.push(
-              new MediaWikiHTML(
-                "center",
-                [current],
-                {},
-                { collapsed: false }
-              )
+              new MediaWikiHTML("center", [current], {}, { collapsed: false })
             );
           }
         } else {


### PR DESCRIPTION
**Description**
This pull request improves the parsing and transformation of YouTube video captions in news content, ensuring that fallback captions (such as "If you can't see the embedded content above, click here") are correctly preserved and displayed alongside embedded YouTube videos. The changes enhance both the parsing logic and the transformer responsible for formatting YouTube embeds, and add comprehensive tests to cover these scenarios.

**YouTube Caption Parsing and Transformation Improvements:**

* The `divParser` now correctly preserves text and links within fallback caption divs, ensuring that captions like "If you can't see the embedded content above, click here" are not lost during parsing.
* The `NewsYoutubeTransformer` is updated to detect and wrap YouTube embeds together with their fallback captions (text + link + text) inside `<center>` tags, providing proper formatting for captions that include links. [[1]](diffhunk://#diff-7810e6a4369f4981500ff5bd9045b90d6b7b677b3bf54efa14aef86f682e625aL21-R59) [[2]](diffhunk://#diff-7810e6a4369f4981500ff5bd9045b90d6b7b677b3bf54efa14aef86f682e625aL58-R87)

**Testing Enhancements:**

* New and updated tests are added for both the `divParser` and `pollBoxParser` to verify that fallback captions and surrounding text are preserved and parsed as expected. [[1]](diffhunk://#diff-4de07119bb35f78b9ede6ae2095d3d13a360563f9f38fd60fa5fc1d44cd44b3eR77-R85) [[2]](diffhunk://#diff-0307297b99faf28a636385cdc41caba059487b47b293407de2ccd19d6c70bd13R95-R107)
* Additional tests are included for the YouTube transformer to ensure the correct output when handling captions with links, including snapshot updates. [[1]](diffhunk://#diff-13eac93fcf6fb08c864e0b8ad64c8042a680421ef843a094e074231eeedbf979L115-R129) [[2]](diffhunk://#diff-13eac93fcf6fb08c864e0b8ad64c8042a680421ef843a094e074231eeedbf979R153-R184) [[3]](diffhunk://#diff-9f2c5658571a5945b5cebbdf4545447fd22f165d2240bdcbbcd632493fa8ec74R23-R30) [[4]](diffhunk://#diff-5106c229bebd5d3d07bd9f4bddcdf4104aba43f65a54e6b3bc91aa47001b7c57R3-R4)

**Miscellaneous:**

* Minor formatting and import adjustments to support the new logic and tests. [[1]](diffhunk://#diff-7810e6a4369f4981500ff5bd9045b90d6b7b677b3bf54efa14aef86f682e625aR4) [[2]](diffhunk://#diff-13eac93fcf6fb08c864e0b8ad64c8042a680421ef843a094e074231eeedbf979R5)

These changes ensure that YouTube embeds in news articles are accurately represented with their intended captions, improving both the reliability and readability of the output.