### PR TITLE
fix: Fix image width parsing & image caption transforming

### DIFF
--- a/.changeset/wide-eels-fly.md
+++ b/.changeset/wide-eels-fly.md
@@ -1,0 +1,5 @@
+---
+"osrs-web-scraper": patch
+---
+
+Fix news image widths not respecting `data-width` or inline `style="width: ..."` attributes, causing them to default to 600px

--- a/.changeset/wide-eels-fly.md
+++ b/.changeset/wide-eels-fly.md
@@ -2,4 +2,4 @@
 "osrs-web-scraper": patch
 ---
 
-Fix news image widths not respecting `data-width` or inline `style="width: ..."` attributes, causing them to default to 600px
+Fix news image widths not respecting `data-width` or inline `style="width: ..."` attributes (causing them to default to 600px), add support for `data-link-href`/`data-caption-href` as image link sources, and fix duplicated/truncated image captions where the file's caption (from a truncated `data-caption-text` attribute) was not being replaced by the full caption from a following `image-caption` div

--- a/src/scrapers/news/sections/newsContent/nodes/__tests__/__snapshots__/image.test.ts.snap
+++ b/src/scrapers/news/sections/newsContent/nodes/__tests__/__snapshots__/image.test.ts.snap
@@ -7,31 +7,31 @@ exports[`image node Image node should parse and render 1`] = `
 `;
 
 exports[`image node Image with both data-caption-text and data-caption-link 1`] = `
-"[[File:test-title (3).png|thumb|600px|center|''Custom caption text.''|link=https://example.com/]]
+"[[File:test-title (1).png|thumb|600px|center|''Custom caption text.''|link=https://example.com/]]
 
 "
 `;
 
 exports[`image node Image with data-caption-text should include italic caption 1`] = `
-"[[File:test-title (2).png|thumb|500px|center|''This is a test caption.'']]
+"[[File:test-title (1).png|thumb|500px|center|''This is a test caption.'']]
 
 "
 `;
 
 exports[`image node Image with data-link-href attribute should use that as the file link 1`] = `
-"[[File:test-title (7).png|200px|link=https://example.com/platform]]
+"[[File:test-title (1).png|200px|link=https://example.com/platform]]
 
 "
 `;
 
 exports[`image node Image with data-width attribute should use that width 1`] = `
-"[[File:test-title (4).png|200px]]
+"[[File:test-title (1).png|200px]]
 
 "
 `;
 
 exports[`image node Image with inline style width should use that width 1`] = `
-"[[File:test-title (5).png|300px]]
+"[[File:test-title (1).png|300px]]
 
 "
 `;

--- a/src/scrapers/news/sections/newsContent/nodes/__tests__/__snapshots__/image.test.ts.snap
+++ b/src/scrapers/news/sections/newsContent/nodes/__tests__/__snapshots__/image.test.ts.snap
@@ -17,3 +17,15 @@ exports[`image node Image with data-caption-text should include italic caption 1
 
 "
 `;
+
+exports[`image node Image with data-width attribute should use that width 1`] = `
+"[[File:test-title (4).png|200px]]
+
+"
+`;
+
+exports[`image node Image with inline style width should use that width 1`] = `
+"[[File:test-title (5).png|300px]]
+
+"
+`;

--- a/src/scrapers/news/sections/newsContent/nodes/__tests__/__snapshots__/image.test.ts.snap
+++ b/src/scrapers/news/sections/newsContent/nodes/__tests__/__snapshots__/image.test.ts.snap
@@ -18,6 +18,12 @@ exports[`image node Image with data-caption-text should include italic caption 1
 "
 `;
 
+exports[`image node Image with data-link-href attribute should use that as the file link 1`] = `
+"[[File:test-title (7).png|200px|link=https://example.com/platform]]
+
+"
+`;
+
 exports[`image node Image with data-width attribute should use that width 1`] = `
 "[[File:test-title (4).png|200px]]
 

--- a/src/scrapers/news/sections/newsContent/nodes/__tests__/image.test.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/__tests__/image.test.ts
@@ -64,4 +64,51 @@ describe("image node", () => {
     builder.addContents(content);
     expect(builder.build()).toMatchSnapshot();
   });
+
+  test("Image with data-width attribute should use that width", () => {
+    const root = parse(
+      '<img src="https://test.com/image.png" data-width="200" />'
+    );
+
+    const result = imageParser(root.firstChild, { title: "test-title" });
+    const content = Array.isArray(result) ? result : [result];
+
+    expect(content[0]).toBeInstanceOf(MediaWikiFile);
+    const file = content[0] as MediaWikiFile;
+    expect(file.options?.resizing?.width).toBe(200);
+
+    const builder = new MediaWikiBuilder();
+    builder.addContents(content);
+    expect(builder.build()).toMatchSnapshot();
+  });
+
+  test("Image with inline style width should use that width", () => {
+    const root = parse(
+      '<img src="https://test.com/image.png" style="width: 300px;" />'
+    );
+
+    const result = imageParser(root.firstChild, { title: "test-title" });
+    const content = Array.isArray(result) ? result : [result];
+
+    expect(content[0]).toBeInstanceOf(MediaWikiFile);
+    const file = content[0] as MediaWikiFile;
+    expect(file.options?.resizing?.width).toBe(300);
+
+    const builder = new MediaWikiBuilder();
+    builder.addContents(content);
+    expect(builder.build()).toMatchSnapshot();
+  });
+
+  test("width attribute takes priority over data-width", () => {
+    const root = parse(
+      '<img src="https://test.com/image.png" width="150" data-width="400" />'
+    );
+
+    const result = imageParser(root.firstChild, { title: "test-title" });
+    const content = Array.isArray(result) ? result : [result];
+
+    expect(content[0]).toBeInstanceOf(MediaWikiFile);
+    const file = content[0] as MediaWikiFile;
+    expect(file.options?.resizing?.width).toBe(150);
+  });
 });

--- a/src/scrapers/news/sections/newsContent/nodes/__tests__/image.test.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/__tests__/image.test.ts
@@ -111,4 +111,60 @@ describe("image node", () => {
     const file = content[0] as MediaWikiFile;
     expect(file.options?.resizing?.width).toBe(150);
   });
+
+  test("Image with data-link-href attribute should use that as the file link", () => {
+    const root = parse(
+      '<img src="https://test.com/image.png" data-width="200" data-link-href="https://example.com/platform" />'
+    );
+
+    const result = imageParser(root.firstChild, { title: "test-title" });
+    const content = Array.isArray(result) ? result : [result];
+
+    expect(content[0]).toBeInstanceOf(MediaWikiFile);
+    const file = content[0] as MediaWikiFile;
+    expect(file.options?.link).toBe("https://example.com/platform");
+
+    const builder = new MediaWikiBuilder();
+    builder.addContents(content);
+    expect(builder.build()).toMatchSnapshot();
+  });
+
+  test("Image with data-caption-href attribute should use that as the file link", () => {
+    const root = parse(
+      '<img src="https://test.com/image.png" data-width="200" data-caption-href="https://example.com/caption-link" />'
+    );
+
+    const result = imageParser(root.firstChild, { title: "test-title" });
+    const content = Array.isArray(result) ? result : [result];
+
+    expect(content[0]).toBeInstanceOf(MediaWikiFile);
+    const file = content[0] as MediaWikiFile;
+    expect(file.options?.link).toBe("https://example.com/caption-link");
+  });
+
+  test("data-caption-link takes priority over data-caption-href", () => {
+    const root = parse(
+      '<img src="https://test.com/image.png" data-width="200" data-caption-link="https://example.com/link" data-caption-href="https://example.com/href" />'
+    );
+
+    const result = imageParser(root.firstChild, { title: "test-title" });
+    const content = Array.isArray(result) ? result : [result];
+
+    expect(content[0]).toBeInstanceOf(MediaWikiFile);
+    const file = content[0] as MediaWikiFile;
+    expect(file.options?.link).toBe("https://example.com/link");
+  });
+
+  test("data-caption-href takes priority over data-link-href", () => {
+    const root = parse(
+      '<img src="https://test.com/image.png" data-width="200" data-caption-href="https://example.com/caption" data-link-href="https://example.com/link-href" />'
+    );
+
+    const result = imageParser(root.firstChild, { title: "test-title" });
+    const content = Array.isArray(result) ? result : [result];
+
+    expect(content[0]).toBeInstanceOf(MediaWikiFile);
+    const file = content[0] as MediaWikiFile;
+    expect(file.options?.link).toBe("https://example.com/caption");
+  });
 });

--- a/src/scrapers/news/sections/newsContent/nodes/__tests__/image.test.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/__tests__/image.test.ts
@@ -2,10 +2,12 @@ import { MediaWikiBuilder, MediaWikiFile } from "@osrs-wiki/mediawiki-builder";
 import fs from "fs";
 import parse from "node-html-parser";
 
+import { ContentContext } from "../../newsContent";
 import imageParser from "../image";
 
 describe("image node", () => {
   beforeEach(() => {
+    ContentContext.imageCount = 0;
     jest.spyOn(fs, "existsSync").mockImplementation(() => false);
     jest.spyOn(fs, "mkdirSync").mockImplementation(() => "");
   });
@@ -97,6 +99,34 @@ describe("image node", () => {
     const builder = new MediaWikiBuilder();
     builder.addContents(content);
     expect(builder.build()).toMatchSnapshot();
+  });
+
+  test("Image with style containing max-width should not be mistaken for width", () => {
+    const root = parse(
+      '<img src="https://test.com/image.png" style="max-width: 800px; width: 300px;" />'
+    );
+
+    const result = imageParser(root.firstChild, { title: "test-title" });
+    const content = Array.isArray(result) ? result : [result];
+
+    expect(content[0]).toBeInstanceOf(MediaWikiFile);
+    const file = content[0] as MediaWikiFile;
+    expect(file.options?.resizing?.width).toBe(300);
+  });
+
+  test("Image with only max-width in style should fall back to sizeOf/default", () => {
+    const root = parse(
+      '<img src="https://test.com/image.png" style="max-width: 800px;" />'
+    );
+
+    const result = imageParser(root.firstChild, { title: "test-title" });
+    const content = Array.isArray(result) ? result : [result];
+
+    expect(content[0]).toBeInstanceOf(MediaWikiFile);
+    const file = content[0] as MediaWikiFile;
+    // No usable width source (no width/data-width/style width, and no real file on disk),
+    // so it should fall back to the default of 600, not the max-width value of 800.
+    expect(file.options?.resizing?.width).toBe(600);
   });
 
   test("width attribute takes priority over data-width", () => {

--- a/src/scrapers/news/sections/newsContent/nodes/image.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/image.ts
@@ -19,6 +19,7 @@ import { ContentNodeParser } from "../types";
 
 const ignoredClasses = ["demo cursor"];
 const imageExtensions = ["png", "jpg", "gif"];
+const REGEX_STYLE_WIDTH = /width\s*:\s*([0-9]+)/i;
 
 export const imageParser: ContentNodeParser = (
   node,
@@ -50,8 +51,12 @@ export const imageParser: ContentNodeParser = (
 
     let dimensions;
     try {
-      if (image.attributes.width) {
-        dimensions = { width: parseInt(image.attributes.width) };
+      const styleWidth = image.attributes.style?.match(REGEX_STYLE_WIDTH)?.[1];
+      const explicitWidth =
+        image.attributes.width ?? image.attributes["data-width"] ?? styleWidth;
+
+      if (explicitWidth) {
+        dimensions = { width: parseInt(explicitWidth) };
       } else {
         // Try to find the image file, which might have a corrected extension
         if (

--- a/src/scrapers/news/sections/newsContent/nodes/image.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/image.ts
@@ -19,7 +19,7 @@ import { ContentNodeParser } from "../types";
 
 const ignoredClasses = ["demo cursor"];
 const imageExtensions = ["png", "jpg", "gif"];
-const REGEX_STYLE_WIDTH = /width\s*:\s*([0-9]+)/i;
+const REGEX_WIDTH_DECLARATION = /^width\s*:\s*([0-9]+)/i;
 
 export const imageParser: ContentNodeParser = (
   node,
@@ -51,7 +51,12 @@ export const imageParser: ContentNodeParser = (
 
     let dimensions;
     try {
-      const styleWidth = image.attributes.style?.match(REGEX_STYLE_WIDTH)?.[1];
+      // Only match a `width` declaration itself, not `max-width`/`min-width`/`border-width` etc.
+      const styleWidth = image.attributes.style
+        ?.split(";")
+        .map((declaration) => declaration.trim())
+        .find((declaration) => REGEX_WIDTH_DECLARATION.test(declaration))
+        ?.match(REGEX_WIDTH_DECLARATION)?.[1];
       const explicitWidth =
         image.attributes.width ?? image.attributes["data-width"] ?? styleWidth;
 
@@ -81,7 +86,7 @@ export const imageParser: ContentNodeParser = (
     ]*/
     const hasCaption = !!captionText;
 
-    // Use link from context if available (from preceding <a> tag), otherwise Button.png check,
+    // Use link from context only for Button.png images (link from a preceding <a> tag),
     // otherwise a caption link, otherwise a data-link-href attribute, otherwise undefined
     const fileLink =
       imageLink.includes("Button.png") && link

--- a/src/scrapers/news/sections/newsContent/nodes/image.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/image.ts
@@ -71,7 +71,9 @@ export const imageParser: ContentNodeParser = (
       console.error(`Error retrieving image size for ${imageName}:`, error);
     }
 
-    const captionLink = image.attributes["data-caption-link"];
+    const captionLink =
+      image.attributes["data-caption-link"] ??
+      image.attributes["data-caption-href"];
     const captionText = image.attributes["data-caption-text"]; /* ?? [
       new MediaWikiText("If you can't see the asset above, "),
       new MediaWikiExternalLink("click here", imageLink),
@@ -79,12 +81,15 @@ export const imageParser: ContentNodeParser = (
     ]*/
     const hasCaption = !!captionText;
 
-    // Use link from context if available (from preceding <a> tag), otherwise Button.png check, otherwise undefined
+    // Use link from context if available (from preceding <a> tag), otherwise Button.png check,
+    // otherwise a caption link, otherwise a data-link-href attribute, otherwise undefined
     const fileLink =
       imageLink.includes("Button.png") && link
         ? (link as string)
         : captionLink
         ? captionLink
+        : image.attributes["data-link-href"]
+        ? image.attributes["data-link-href"]
         : undefined;
 
     const caption = captionText

--- a/src/scrapers/news/transformers/__tests__/__snapshots__/fileCaptionTransformer.test.ts.snap
+++ b/src/scrapers/news/transformers/__tests__/__snapshots__/fileCaptionTransformer.test.ts.snap
@@ -24,7 +24,4 @@ exports[`NewsFileCaptionTransformer should combine the adjacent MediaWikiFile, M
 "
 `;
 
-exports[`NewsFileCaptionTransformer should skip files that already have captions 1`] = `
-"[[File:image|''existing caption'']]
-''another caption''"
-`;
+exports[`NewsFileCaptionTransformer should override an existing (e.g. truncated data-caption-text) caption with the full following caption 1`] = `"[[File:image|thumb|''another caption'']]"`;

--- a/src/scrapers/news/transformers/__tests__/fileCaptionTransformer.test.ts
+++ b/src/scrapers/news/transformers/__tests__/fileCaptionTransformer.test.ts
@@ -25,7 +25,7 @@ describe("NewsFileCaptionTransformer", () => {
     ).toMatchSnapshot();
   });
 
-  it("should skip files that already have captions", () => {
+  it("should override an existing (e.g. truncated data-caption-text) caption with the full following caption", () => {
     const originalContent: MediaWikiContent[] = [
       new MediaWikiFile("image", {
         caption: new MediaWikiText("existing caption", { italics: true }),
@@ -39,8 +39,8 @@ describe("NewsFileCaptionTransformer", () => {
       originalContent
     );
 
-    // Should not combine since file already has caption
-    expect(transformed).toHaveLength(3);
+    // Should combine, with the following full caption taking precedence
+    expect(transformed).toHaveLength(1);
     expect(transformed[0]).toBeInstanceOf(MediaWikiFile);
     const file = transformed[0] as MediaWikiFile;
     expect(file.options?.caption).toBeInstanceOf(MediaWikiText);

--- a/src/scrapers/news/transformers/fileCaptionTransformer.ts
+++ b/src/scrapers/news/transformers/fileCaptionTransformer.ts
@@ -16,12 +16,15 @@ class NewsFileCaptionTransformer extends MediaWikiTransformer {
       const transformedContent = [];
       for (let index = 0; index < content.length; index++) {
         const current = content[index];
-        if (current instanceof MediaWikiFile && !current.options?.caption) {
+        if (current instanceof MediaWikiFile) {
           const next = getNextContent(content, index + 1);
           if (
             next.content instanceof MediaWikiText &&
             Array.isArray(next.content.children)
           ) {
+            // A fully-formed caption (e.g. from an "image-caption" div) follows the
+            // file, so it takes precedence over any caption already set on the file
+            // (which may be a truncated `data-caption-text` attribute value).
             transformedContent.push(
               new MediaWikiFile(current.fileName, {
                 ...current.options,


### PR DESCRIPTION
**Description**
This pull request addresses several issues with image handling in the news scraper, focusing on image sizing, linking, and caption logic. The main improvements are: images now correctly respect `data-width` and inline `style="width:..."` attributes for sizing, support is added for `data-link-href` and `data-caption-href` attributes as image link sources, and image captions are no longer duplicated or truncated—if a full caption is present after the image, it replaces any partial caption from the image tag.

**Image sizing improvements:**
- Images now use the `width` attribute, `data-width`, or inline `style="width:..."` (in that order of priority) to set their width, fixing the previous default to 600px. [[1]](diffhunk://#diff-0e46abf179f6f66c10c6f3eaa85c0f05571f107c273f146a2381fa4a5e8e6340L53-R59) [[2]](diffhunk://#diff-af1ce7d03ee8c5d4629cde34b7b552dc25d34b850c532c72c34f52bf807c8e2aR67-R169) [[3]](diffhunk://#diff-4b10c082847a17033941167d4c2996f9a727884e412e8c87b1a316614835fa43R20-R37)

**Image linking enhancements:**
- The parser now supports `data-link-href` and `data-caption-href` as sources for the image's link, with a defined priority order: `data-caption-link` > `data-caption-href` > `data-link-href`. [[1]](diffhunk://#diff-0e46abf179f6f66c10c6f3eaa85c0f05571f107c273f146a2381fa4a5e8e6340L69-R92) [[2]](diffhunk://#diff-af1ce7d03ee8c5d4629cde34b7b552dc25d34b850c532c72c34f52bf807c8e2aR67-R169) [[3]](diffhunk://#diff-4b10c082847a17033941167d4c2996f9a727884e412e8c87b1a316614835fa43R20-R37)

**Image caption logic fixes:**
- If a full caption follows an image (e.g., in an `image-caption` div), it now overrides any existing caption on the image, such as a truncated `data-caption-text` value, preventing duplicated or truncated captions. [[1]](diffhunk://#diff-549d530aaa916b2c47832029ce1ad830b47401de1104f7b55563ed6309b06204L19-R27) [[2]](diffhunk://#diff-ac2c24f9f703e9ef1152c4394353672b1e72f343c37289de24a8e704f1bf5f6eL28-R28) [[3]](diffhunk://#diff-ac2c24f9f703e9ef1152c4394353672b1e72f343c37289de24a8e704f1bf5f6eL42-R43) [[4]](diffhunk://#diff-fe5fe300006e37b1c50a2d37f16cb353bc5e231473d901b128cdd06510e0647aL27-R27)

**Testing updates:**
- Added and updated tests to cover the new width and link handling logic, as well as the improved caption replacement behavior. [[1]](diffhunk://#diff-af1ce7d03ee8c5d4629cde34b7b552dc25d34b850c532c72c34f52bf807c8e2aR67-R169) [[2]](diffhunk://#diff-4b10c082847a17033941167d4c2996f9a727884e412e8c87b1a316614835fa43R20-R37) [[3]](diffhunk://#diff-ac2c24f9f703e9ef1152c4394353672b1e72f343c37289de24a8e704f1bf5f6eL28-R28) [[4]](diffhunk://#diff-ac2c24f9f703e9ef1152c4394353672b1e72f343c37289de24a8e704f1bf5f6eL42-R43) [[5]](diffhunk://#diff-fe5fe300006e37b1c50a2d37f16cb353bc5e231473d901b128cdd06510e0647aL27-R27)

**Documentation:**
- The `.changeset` file summarizes these fixes and enhancements for release tracking.