### PR TITLE
fix: Resolve gallery parsing issues with osrs-carousel markup

### DIFF
--- a/.changeset/tame-donuts-drum.md
+++ b/.changeset/tame-donuts-drum.md
@@ -1,0 +1,5 @@
+---
+"osrs-web-scraper": patch
+---
+
+Fix galleries not parsing correctly when using the new `osrs-carousel` markup, causing them to render as a flat list of `[[File:...]]` images instead of a `<gallery>` block; also fix gallery entries not referencing the actual downloaded filename when its extension was corrected based on MIME type

--- a/src/scrapers/news/sections/newsContent/nodes/__tests__/div.test.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/__tests__/div.test.ts
@@ -39,9 +39,11 @@ describe("div node", () => {
     expect(result).toBeDefined();
     // The result should be a gallery parser result with the tag "gallery"
     expect(result).toEqual(
-      expect.objectContaining({
-        tag: "gallery",
-      })
+      expect.arrayContaining([
+        expect.objectContaining({
+          tag: "gallery",
+        }),
+      ])
     );
   });
 
@@ -53,9 +55,11 @@ describe("div node", () => {
     expect(result).toBeDefined();
     // The result should be a gallery parser result with the tag "gallery"
     expect(result).toEqual(
-      expect.objectContaining({
-        tag: "gallery",
-      })
+      expect.arrayContaining([
+        expect.objectContaining({
+          tag: "gallery",
+        }),
+      ])
     );
   });
 

--- a/src/scrapers/news/sections/newsContent/nodes/__tests__/div.test.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/__tests__/div.test.ts
@@ -45,6 +45,20 @@ describe("div node", () => {
     );
   });
 
+  test("osrs-carousel class should parse as gallery", () => {
+    const root = parse(
+      '<div class="osrs-carousel" data-carousel=""><div class="osrs-carousel__slide"><img src="https://example.com/image1.png"><div class="osrs-carousel__caption">Caption text</div></div></div>'
+    );
+    const result = divParser(root.firstChild, { title: "Test Post" });
+    expect(result).toBeDefined();
+    // The result should be a gallery parser result with the tag "gallery"
+    expect(result).toEqual(
+      expect.objectContaining({
+        tag: "gallery",
+      })
+    );
+  });
+
   test("osrs-title class should parse as level 2 header", () => {
     const root = parse('<div class="osrs-title">Main Title</div>');
     const builder = new MediaWikiBuilder();

--- a/src/scrapers/news/sections/newsContent/nodes/div/__tests__/__snapshots__/gallery.test.ts.snap
+++ b/src/scrapers/news/sections/newsContent/nodes/div/__tests__/__snapshots__/gallery.test.ts.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`gallery node Carousel gallery (osrs-carousel) should parse img slides and render gallery 1`] = `
+"<gallery mode=\\"packed\\", heights=\\"180\\", style=\\"text-align:center\\">
+test-title (1).jpg|[https://x.com/Legend_Arts Legend Arts] has captured the true majesty of ''Lord Drakan''!
+test-title (2).jpg|MissyTheBaker cooked up this stunning Ironman trio.
+test-title (3).png
+</gallery>
+"
+`;
+
 exports[`gallery node Gallery should parse and render 1`] = `
 "<gallery mode=\\"packed\\", heights=\\"180\\", style=\\"text-align:center\\">
 test-title (1).png

--- a/src/scrapers/news/sections/newsContent/nodes/div/__tests__/__snapshots__/gallery.test.ts.snap
+++ b/src/scrapers/news/sections/newsContent/nodes/div/__tests__/__snapshots__/gallery.test.ts.snap
@@ -6,6 +6,7 @@ test-title (1).jpg|[https://x.com/Legend_Arts Legend Arts] has captured the true
 test-title (2).jpg|MissyTheBaker cooked up this stunning Ironman trio.
 test-title (3).png
 </gallery>
+
 "
 `;
 
@@ -14,6 +15,7 @@ exports[`gallery node Gallery should parse and render 1`] = `
 test-title (1).png
 test-title (2).jpg
 </gallery>
+
 "
 `;
 
@@ -24,5 +26,6 @@ HD & Plugin API Progress Update (2).png
 HD & Plugin API Progress Update (3).png
 HD & Plugin API Progress Update (4).png
 </gallery>
+
 "
 `;

--- a/src/scrapers/news/sections/newsContent/nodes/div/__tests__/gallery.test.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/div/__tests__/gallery.test.ts
@@ -34,10 +34,95 @@ describe("gallery node", () => {
     });
   });
 
+  test("Carousel gallery (osrs-carousel) should parse img slides and render gallery", () => {
+    ContentContext.imageCount = 0;
+
+    const existsSyncSpy = jest
+      .spyOn(fs, "existsSync")
+      .mockImplementation(() => false);
+    const mkdirSyncSpy = jest
+      .spyOn(fs, "mkdirSync")
+      .mockImplementation(() => "");
+
+    const root = parse(`
+      <div class="osrs-carousel" data-carousel="">
+        <div class="osrs-carousel__thumbs" data-carousel-thumbs=""></div>
+        <div class="osrs-carousel__slide">
+          <img src="https://example.com/legendartsdrakan.jpg">
+          <div class="osrs-carousel__caption"><a href="https://x.com/Legend_Arts">Legend Arts</a> has captured the true majesty of <i>Lord Drakan</i>!</div>
+        </div>
+        <div class="osrs-carousel__slide">
+          <img src="https://example.com/missythebaker1.jpg" data-caption-full="MissyTheBaker cooked up this stunning Ironman trio.">
+        </div>
+        <div class="osrs-carousel__slide">
+          <img src="https://example.com/drunkenmonk.png">
+        </div>
+        <div class="osrs-carousel__slide osrs-carousel__video"
+          data-video="https://example.com/video.mp4"
+          data-thumbnail="https://example.com/video-thumbnail.png">
+          <div class="osrs-carousel__caption">Video slide with no img tag</div>
+        </div>
+        <div class="image-caption" data-carousel-caption></div>
+      </div>
+    `);
+
+    const carouselDiv = root.querySelector(".osrs-carousel");
+    const builder = new MediaWikiBuilder();
+    builder.addContents(
+      [galleryParser(carouselDiv, { title: "test-title" })].flat()
+    );
+    const result = builder.build();
+
+    expect(result).toContain("<gallery");
+    // Caption from an .osrs-carousel__caption element (converted to wikitext, preserving the link and italics)
+    expect(result).toContain(
+      "test-title (1).jpg|[https://x.com/Legend_Arts Legend Arts] has captured the true majesty of ''Lord Drakan''!"
+    );
+    // Caption falls back to the img's data-caption-full attribute when there's no caption element
+    expect(result).toContain(
+      "test-title (2).jpg|MissyTheBaker cooked up this stunning Ironman trio."
+    );
+    // No caption at all should just render the filename
+    expect(result).toContain("test-title (3).png");
+    expect(result).not.toMatch(/test-title \(3\)\.png\|/);
+    // The video slide has no <img> tag, so only the three image slides should be counted
+    expect(ContentContext.imageCount).toBe(3);
+    expect(result).toMatchSnapshot();
+
+    expect(existsSyncSpy).toHaveBeenCalledWith("./out/news/test-title");
+    expect(mkdirSyncSpy).toHaveBeenCalledWith("./out/news/test-title", {
+      recursive: true,
+    });
+  });
+
+  test("Gallery should reference the actual downloaded filename when the extension was corrected", () => {
+    ContentContext.imageCount = 0;
+
+    jest.spyOn(fs, "existsSync").mockImplementation(() => true);
+    jest.spyOn(fs, "mkdirSync").mockImplementation(() => "");
+    // Simulate a file downloaded as .jpeg that was corrected to .jpg based on MIME type
+    jest
+      .spyOn(fs, "readdirSync")
+      .mockImplementation(() => ["test-title (1).jpg"] as never);
+
+    const root = parse(`
+      <div class="row">
+        <img src="https://example.com/image1.jpeg" />
+      </div>
+    `);
+
+    const builder = new MediaWikiBuilder();
+    builder.addContents([galleryParser(root, { title: "test-title" })].flat());
+    const result = builder.build();
+
+    expect(result).toContain("test-title (1).jpg");
+    expect(result).not.toContain("test-title (1).jpeg");
+  });
+
   test("Image slider should parse figure background images and render gallery", () => {
     // Reset image counter for consistent test results
     ContentContext.imageCount = 0;
-    
+
     const existsSyncSpy = jest
       .spyOn(fs, "existsSync")
       .mockImplementation(() => false);
@@ -66,17 +151,23 @@ describe("gallery node", () => {
       </div>
     `);
 
-    const slideshowDiv = root.querySelector('#slideshow-container');
+    const slideshowDiv = root.querySelector("#slideshow-container");
     const builder = new MediaWikiBuilder();
-    builder.addContents([galleryParser(slideshowDiv, { title: "HD & Plugin API Progress Update" })].flat());
+    builder.addContents(
+      [
+        galleryParser(slideshowDiv, {
+          title: "HD & Plugin API Progress Update",
+        }),
+      ].flat()
+    );
     const result = builder.build();
-    
+
     // Should create a gallery with background images from figure and divisor elements
-    expect(result).toContain('<gallery');
-    expect(result).toContain('HD & Plugin API Progress Update (1).png');
-    expect(result).toContain('HD & Plugin API Progress Update (2).png'); 
-    expect(result).toContain('HD & Plugin API Progress Update (3).png');
-    expect(result).toContain('HD & Plugin API Progress Update (4).png');
+    expect(result).toContain("<gallery");
+    expect(result).toContain("HD & Plugin API Progress Update (1).png");
+    expect(result).toContain("HD & Plugin API Progress Update (2).png");
+    expect(result).toContain("HD & Plugin API Progress Update (3).png");
+    expect(result).toContain("HD & Plugin API Progress Update (4).png");
     expect(result).toMatchSnapshot();
 
     expect(existsSyncSpy).toHaveBeenCalled();

--- a/src/scrapers/news/sections/newsContent/nodes/div/div.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/div/div.ts
@@ -14,6 +14,7 @@ const classParserMap: { [key: string]: ContentNodeParser } = {
   "poll-box": pollBoxParser,
   "poll-box2": pollBoxParser,
   "row": galleryParser,
+  "osrs-carousel": galleryParser,
   "osrs-title": osrsHeaderParser,
   "osrs-subtitle": osrsHeaderParser,
   "osrs-subheading": osrsHeaderParser,

--- a/src/scrapers/news/sections/newsContent/nodes/div/gallery.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/div/gallery.ts
@@ -36,7 +36,7 @@ const buildCaptionText = (
     return undefined;
   }
 
-  const caption = new MediaWikiText(childContent).build();
+  const caption = new MediaWikiText(childContent).build().trim();
   return caption === "" ? undefined : caption;
 };
 
@@ -135,15 +135,15 @@ const handleCarouselGallery = (
   const imageDirectory = `./out/news/${formattedTitle}`;
   const slides = divElement.querySelectorAll(".osrs-carousel__slide");
 
+  if (!fs.existsSync(imageDirectory)) {
+    fs.mkdirSync(imageDirectory, { recursive: true });
+  }
+
   slides.forEach((slide) => {
     const imageNode = slide.querySelector("img");
     // Video slides (osrs-carousel__video) have no <img> tag and aren't downloaded, so skip them
     if (!imageNode) {
       return;
-    }
-
-    if (!fs.existsSync(imageDirectory)) {
-      fs.mkdirSync(imageDirectory, { recursive: true });
     }
 
     const imageLink = imageNode.attributes.src;

--- a/src/scrapers/news/sections/newsContent/nodes/div/gallery.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/div/gallery.ts
@@ -1,4 +1,8 @@
-import { MediaWikiHTML, MediaWikiText } from "@osrs-wiki/mediawiki-builder";
+import {
+  MediaWikiBreak,
+  MediaWikiHTML,
+  MediaWikiText,
+} from "@osrs-wiki/mediawiki-builder";
 import fs from "fs";
 import { HTMLElement } from "node-html-parser";
 
@@ -201,11 +205,14 @@ export const galleryParser: ContentNodeParser = (node, options) => {
     const handler = galleryHandlers[galleryType];
     const content = handler(divElement, options);
 
-    return new MediaWikiHTML("gallery", content, {
-      mode: "packed",
-      heights: "180",
-      style: "text-align:center",
-    });
+    return [
+      new MediaWikiHTML("gallery", content, {
+        mode: "packed",
+        heights: "180",
+        style: "text-align:center",
+      }),
+      new MediaWikiBreak(),
+    ];
   }
 };
 

--- a/src/scrapers/news/sections/newsContent/nodes/div/gallery.ts
+++ b/src/scrapers/news/sections/newsContent/nodes/div/gallery.ts
@@ -3,9 +3,42 @@ import fs from "fs";
 import { HTMLElement } from "node-html-parser";
 
 import { extractBackgroundImageUrl } from "../../../../../../utils/css";
-import { formatFileName, getFileExtension } from "../../../../../../utils/file";
+import {
+  findFileByBaseName,
+  formatFileName,
+  getFileExtension,
+} from "../../../../../../utils/file";
 import { ContentContext } from "../../newsContent";
 import { ContentNodeParser } from "../../types";
+import nodeParser from "../parser";
+import textParser from "../text";
+
+// Helper function to convert a caption element's child nodes (text, links, italics, etc.)
+// into a single line of wikitext suitable for a gallery caption
+const buildCaptionText = (
+  captionElement: HTMLElement | null,
+  options: { [key: string]: string | boolean | number }
+): string | undefined => {
+  if (!captionElement) {
+    return undefined;
+  }
+
+  const childContent = captionElement.childNodes
+    .map((childNode) =>
+      childNode instanceof HTMLElement
+        ? nodeParser(childNode, options)
+        : textParser(childNode, options)
+    )
+    .flat()
+    .filter((content) => content != null);
+
+  if (childContent.length === 0) {
+    return undefined;
+  }
+
+  const caption = new MediaWikiText(childContent).build();
+  return caption === "" ? undefined : caption;
+};
 
 // Helper function to process background image elements and add them to content
 const processBackgroundImageElement = (
@@ -23,24 +56,31 @@ const processBackgroundImageElement = (
 
       const imageName = `${formattedTitle} (${++ContentContext.imageCount})`;
       const imageExtension = getFileExtension(imageUrl);
-      
-      content.push(new MediaWikiText(
-        `${content.length === 0 ? "" : "\n"}${imageName}.${imageExtension}`
-      ));
+
+      // Check if the file exists with a different extension (due to MIME type correction)
+      const actualFileName = findFileByBaseName(imageDirectory, imageName);
+      const fileNameToUse = actualFileName || `${imageName}.${imageExtension}`;
+
+      content.push(
+        new MediaWikiText(`${content.length === 0 ? "" : "\n"}${fileNameToUse}`)
+      );
     }
   }
 };
 
 // Handler for slideshow container galleries with background images
-const handleSlideshowGallery = (divElement: HTMLElement, options: { [key: string]: string | boolean | number }): MediaWikiText[] => {
+const handleSlideshowGallery = (
+  divElement: HTMLElement,
+  options: { [key: string]: string | boolean | number }
+): MediaWikiText[] => {
   const content: MediaWikiText[] = [];
   const slides = divElement.querySelectorAll(".mySlides");
   const formattedTitle = formatFileName(options.title as string);
-  
+
   slides.forEach((slide) => {
     const figureElement = slide.querySelector("figure");
     const divisorElement = slide.querySelector("div.divisor");
-    
+
     // Extract background image from figure element (SD version)
     processBackgroundImageElement(figureElement, formattedTitle, content);
 
@@ -52,10 +92,13 @@ const handleSlideshowGallery = (divElement: HTMLElement, options: { [key: string
 };
 
 // Handler for regular galleries with img tags
-const handleRegularGallery = (divElement: HTMLElement, options: { [key: string]: string | boolean | number }): MediaWikiText[] => {
+const handleRegularGallery = (
+  divElement: HTMLElement,
+  options: { [key: string]: string | boolean | number }
+): MediaWikiText[] => {
   const content: MediaWikiText[] = [];
   const imageNodes = divElement.querySelectorAll("img");
-  
+
   imageNodes.forEach((imageNode, index) => {
     const image = imageNode as HTMLElement;
     const imageLink = image.attributes.src;
@@ -69,30 +112,92 @@ const handleRegularGallery = (divElement: HTMLElement, options: { [key: string]:
     const imageName = `${formattedTitle} (${++ContentContext.imageCount})`;
     const imageExtension = getFileExtension(imageLink);
 
-    content.push(new MediaWikiText(
-      `${index === 0 ? "" : "\n"}${imageName}.${imageExtension}`
-    ));
+    // Check if the file exists with a different extension (due to MIME type correction)
+    const actualFileName = findFileByBaseName(imageDirectory, imageName);
+    const fileNameToUse = actualFileName || `${imageName}.${imageExtension}`;
+
+    content.push(
+      new MediaWikiText(`${index === 0 ? "" : "\n"}${fileNameToUse}`)
+    );
+  });
+
+  return content;
+};
+
+// Handler for osrs-carousel galleries, which include a caption per slide
+// (either an `.osrs-carousel__caption` element or a `data-caption-full` attribute on the image)
+const handleCarouselGallery = (
+  divElement: HTMLElement,
+  options: { [key: string]: string | boolean | number }
+): MediaWikiText[] => {
+  const content: MediaWikiText[] = [];
+  const formattedTitle = formatFileName(options.title as string);
+  const imageDirectory = `./out/news/${formattedTitle}`;
+  const slides = divElement.querySelectorAll(".osrs-carousel__slide");
+
+  slides.forEach((slide) => {
+    const imageNode = slide.querySelector("img");
+    // Video slides (osrs-carousel__video) have no <img> tag and aren't downloaded, so skip them
+    if (!imageNode) {
+      return;
+    }
+
+    if (!fs.existsSync(imageDirectory)) {
+      fs.mkdirSync(imageDirectory, { recursive: true });
+    }
+
+    const imageLink = imageNode.attributes.src;
+    const imageName = `${formattedTitle} (${++ContentContext.imageCount})`;
+    const imageExtension = getFileExtension(imageLink);
+
+    // Check if the file exists with a different extension (due to MIME type correction)
+    const actualFileName = findFileByBaseName(imageDirectory, imageName);
+    const fileNameToUse = actualFileName || `${imageName}.${imageExtension}`;
+
+    const captionElement = slide.querySelector(".osrs-carousel__caption");
+    const caption =
+      buildCaptionText(captionElement, options) ??
+      imageNode.attributes["data-caption-full"];
+
+    content.push(
+      new MediaWikiText(
+        `${content.length === 0 ? "" : "\n"}${fileNameToUse}${
+          caption ? `|${caption}` : ""
+        }`
+      )
+    );
   });
 
   return content;
 };
 
 // Map of gallery types to their handlers
-const galleryHandlers: { [key: string]: (element: HTMLElement, options: { [key: string]: string | boolean | number }) => MediaWikiText[] } = {
+const galleryHandlers: {
+  [key: string]: (
+    element: HTMLElement,
+    options: { [key: string]: string | boolean | number }
+  ) => MediaWikiText[];
+} = {
   "slideshow-container": handleSlideshowGallery,
+  "osrs-carousel": handleCarouselGallery,
   "default": handleRegularGallery,
 };
 
 export const galleryParser: ContentNodeParser = (node, options) => {
   if (node instanceof HTMLElement && node.childNodes.length > 0) {
     const divElement = node as HTMLElement;
-    
+
     // Determine gallery type and use appropriate handler
     let galleryType = "default";
-    if (divElement.id === "slideshow-container" || divElement.classList.contains("slideshow-container")) {
+    if (
+      divElement.id === "slideshow-container" ||
+      divElement.classList.contains("slideshow-container")
+    ) {
       galleryType = "slideshow-container";
+    } else if (divElement.classList.contains("osrs-carousel")) {
+      galleryType = "osrs-carousel";
     }
-    
+
     const handler = galleryHandlers[galleryType];
     const content = handler(divElement, options);
 


### PR DESCRIPTION
**Description**
This pull request fixes issues with parsing and rendering image galleries, especially for the new `osrs-carousel` markup, and improves how gallery images are referenced after download. The main changes add robust support for carousel galleries (with captions), ensure the correct file extension is used for images, and expand test coverage for these scenarios.

**Gallery Parsing and Rendering Improvements:**

* Added support for parsing `osrs-carousel` galleries as proper `<gallery>` blocks, including handling per-slide captions and skipping non-image slides (e.g., videos). [[1]](diffhunk://#diff-c8b78d45cabced7d2ce6dc98f6eaf5cbe692e1c6aa9ebd76ac0f0ef0dd036e26R17) [[2]](diffhunk://#diff-f2e86a3efb3b44cae5f8f2630123499a7b810c5e986153f77caeacc7a2a0ab3bL72-R182) [[3]](diffhunk://#diff-f2e86a3efb3b44cae5f8f2630123499a7b810c5e986153f77caeacc7a2a0ab3bL92-R198)
* Fixed gallery entries to reference the actual downloaded filename, correcting the extension based on MIME type if needed, rather than assuming the original extension. [[1]](diffhunk://#diff-f2e86a3efb3b44cae5f8f2630123499a7b810c5e986153f77caeacc7a2a0ab3bL27-R75) [[2]](diffhunk://#diff-f2e86a3efb3b44cae5f8f2630123499a7b810c5e986153f77caeacc7a2a0ab3bL72-R182)

**Testing Enhancements:**

* Added comprehensive tests for parsing `osrs-carousel` galleries, including various caption scenarios and ensuring only images are counted.
* Added tests to verify that gallery entries reference the corrected file extension after download.
* Expanded test snapshots and coverage for gallery rendering, including for carousels and background-image galleries. [[1]](diffhunk://#diff-aff098eb05e38bc1fff3153ec23e679025d4b9743b6f70b881ce4bcd8a6bbedfR3-R11) [[2]](diffhunk://#diff-a6292aded2f5451b9e7796d4c650d2afd0b8b289bafccb2db56997c5570d0f35L69-R170)

**Documentation:**

* Updated the changeset to describe the fixes for gallery parsing and filename referencing.